### PR TITLE
Fix avatar defaulting and weapon ammo

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -326,10 +326,10 @@ function getPlayerAvatar(src)
             Citizen.Await(p)
         end
         local resultAvatar = avatar or "assets/default.png"
-        return avatar
+        return resultAvatar
     else
         return "assets/default.png"
-    end     
+    end
 end
 
 function GetStock(category, itemName, cb)
@@ -374,6 +374,6 @@ function SendToDiscord(name, message, color)
                 },
             },
 	    }
-		PerformHttpRequest(DiscordWebhook, function(err, text, headers) end, 'POST', json.encode({username = DISCORD_NAME, embeds = connect, avatarrl = DISCORD_IMAGE}), { ['Content-Type'] = 'application/json' })
-	end
+                PerformHttpRequest(DiscordWebhook, function(err, text, headers) end, 'POST', json.encode({username = DISCORD_NAME, embeds = connect, avatar_url = DISCORD_IMAGE}), { ['Content-Type'] = 'application/json' })
+        end
 end

--- a/utils/server.lua
+++ b/utils/server.lua
@@ -135,7 +135,7 @@ function addWeaponToPlayer(player, weapon, amount)
             player.Functions.AddItem(weapon, 1)
         end
     else
-        player.addWeapon(weapon, ammo)
+        player.addWeapon(weapon, amount)
     end
 end
 


### PR DESCRIPTION
## Summary
- fix missing default avatar when Steam avatar not found
- fix typo in Discord webhook payload (`avatar_url`)
- pass ammo count when adding ESX weapons

## Testing
- `luac -p server/server.lua`
- `luac -p utils/server.lua`

------
https://chatgpt.com/codex/tasks/task_e_6878130d3f388329b05458a752ce2b46