### PR TITLE
Add vehicle stock table info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # VIP System
+
+## SQL
+
+The script uses a table named `vehicle_stock` to store remaining stock for vehicles. `server/server.lua` references this table when updating or checking stock levels. Add the table by running the SQL below or executing `ak4y-vipSystemv2.sql`.
+
+```sql
+CREATE TABLE IF NOT EXISTS vehicle_stock (
+    category VARCHAR(50) NOT NULL,
+    item_name VARCHAR(50) NOT NULL,
+    stock INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (category, item_name)
+);
+```

--- a/ak4y-vipSystemv2.sql
+++ b/ak4y-vipSystemv2.sql
@@ -10,3 +10,10 @@ CREATE TABLE IF NOT EXISTS `ak4y_vipsystemv2_codes` (
   `code` varchar(255) DEFAULT NULL,
   `coinAmount` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+
+CREATE TABLE IF NOT EXISTS vehicle_stock (
+    category VARCHAR(50) NOT NULL,
+    item_name VARCHAR(50) NOT NULL,
+    stock INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (category, item_name)
+);


### PR DESCRIPTION
## Summary
- add SQL table `vehicle_stock`
- document how `server/server.lua` uses the table to keep remaining vehicle stock

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878154304188329a545a14f6fc121e5