### PR TITLE
Enable vehicle stock checks

### DIFF
--- a/config/translate.lua
+++ b/config/translate.lua
@@ -64,5 +64,6 @@ AK4Y.Translate = {
     codeNotFoundText = "Código no encontrado.",
     locationMarked = "Ubicación marcada.",
     plateHasOwnerText = "Esta matrícula ya tiene un propietario.",
+    stockEmptyText = "No queda stock disponible.",
     soFarFromTestDriveArea = "Estás muy lejos del área de prueba.",
 }


### PR DESCRIPTION
## Summary
- add missing translation for stock depletion
- check and reduce stock when buying vehicles or bundles
- return after callbacks in buy item logic

## Testing
- `luajit -b server/server.lua /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_687815fbf9048329b610c91713e04a60